### PR TITLE
Dom JIM API tests and fixes

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -8,3 +8,9 @@ ipcore_dir/create_DCM1.tcl
 ipcore_dir/create_DCM2.tcl
 ipcore_dir/xaw2vhdl.log
 not_in_git/
+usage_statistics_webtalk.html
+webtalk.log
+webtalk_impact.xml
+impact_impact.xwbt
+impact.xsl
+impact.ipf

--- a/src/Music5000.vhd
+++ b/src/Music5000.vhd
@@ -47,7 +47,7 @@ entity Music5000 is
         cycle    : out    std_logic_vector (6 downto 0);
         test     : out    std_logic
     );
-end music5000;
+end Music5000;
 
 architecture Behavioral of Music5000 is
 

--- a/src/Music5000_lx9core.vhd
+++ b/src/Music5000_lx9core.vhd
@@ -88,13 +88,15 @@ begin
             pgfd_n     => pgfd_n     ,
             bus_addr   => bus_addr   ,
             bus_data   => bus_data   ,
+            bus_data_oel=>bus_data_oel,
             dac_cs_n   => dac_cs_n   ,
             dac_sck    => dac_sck    ,
             dac_sdi    => dac_sdi    ,
             dac_ldac_n => dac_ldac_n ,
             enable5    => '1'        ,
             enable3    => '1'        ,
-            irq_n      => irq_n
+            irq_n      => irq_n      ,
+            owl        => sw1
             );
 
     ------------------------------------------------
@@ -104,7 +106,6 @@ begin
     irq          <= not irq_n;
     nmi          <= '0';
 
-    bus_data_oel <= '0' when pgfc_n = '0' or pgfd_n = '0' else '1';
     bus_data_dir <= rnw;
 
     ram_addr     <= (others => '0');


### PR DESCRIPTION
Make OWL logo boot user select able at boot (hold SW1)
FIX: only enable data buffer for reads when necessary - was clobbering all other FRED/JIM devices